### PR TITLE
TypeConverterBase no longer short-circuits generics

### DIFF
--- a/Flame/Build/TypeConverterBase.ds
+++ b/Flame/Build/TypeConverterBase.ds
@@ -45,10 +45,6 @@ namespace Flame.Build
 			{
 				return ConvertPrimitiveType(Type);
 			}
-			else if (Type.DeclaringNamespace is IType)
-			{
-				return ConvertNestedType(Type, (IType)Type.DeclaringNamespace);
-			}
 			else
 			{
 				return ConvertUserType(Type);
@@ -65,6 +61,10 @@ namespace Flame.Build
 			if (Type.IsGenericParameter)
 			{
 				return ConvertGenericParameter((IGenericParameter)Type);
+			}
+			else if (Type.DeclaringNamespace is IType)
+			{
+				return ConvertNestedType(Type, (IType)Type.DeclaringNamespace);
 			}
 			else if (Type.IsEnum)
 			{


### PR DESCRIPTION
Generic parameters were short-circuited by TypeConverterBase<T>, as are
in effect "nested types", which had precedence. This has been changed.
TypeConverterBase<T> will now try to treat a type as a generic parameter
before considering that it may be a nested type.